### PR TITLE
Refactor vassal_test with ExUnitFixtures v0.3.0

### DIFF
--- a/lib/vassal/queue.ex
+++ b/lib/vassal/queue.ex
@@ -133,7 +133,7 @@ defmodule Vassal.Queue do
 
   def run_action(%ListQueues{prefix: prefix}) do
     queues = QueueStore.list_queues
-    if prefix do
+    if prefix != nil and String.length(prefix) > 0 do
       queues = queues |> Enum.filter(&(String.starts_with? &1, prefix))
     end
 

--- a/mix.exs
+++ b/mix.exs
@@ -46,7 +46,7 @@ defmodule Vassal.Mixfile do
      # For testing
      {:erlcloud, "~> 0.12.0", only: [:test]},
      {:httpoison, "~> 0.8.0", only: [:test]},
-     {:ex_unit_fixtures, "~> 0.1.1", only: [:test]},
+     {:ex_unit_fixtures, "~> 0.3.0", only: [:test]},
 
      # For linting etc.
      {:credo, "~> 0.2.0", only: [:dev, :test], warn_missing: false},

--- a/mix.lock
+++ b/mix.lock
@@ -11,7 +11,7 @@
   "erlcloud": {:hex, :erlcloud, "0.12.0"},
   "erlware_commons": {:hex, :erlware_commons, "0.15.0"},
   "esqlite": {:hex, :esqlite, "0.2.1"},
-  "ex_unit_fixtures": {:hex, :ex_unit_fixtures, "0.1.1"},
+  "ex_unit_fixtures": {:hex, :ex_unit_fixtures, "0.3.0"},
   "exactor": {:hex, :exactor, "2.2.0"},
   "exrm": {:hex, :exrm, "1.0.0-rc7"},
   "fsm": {:hex, :fsm, "0.2.0"},

--- a/test/integration_tests/fixtures.exs
+++ b/test/integration_tests/fixtures.exs
@@ -1,0 +1,37 @@
+defmodule IntegrationTestFixtures do
+  use ExUnitFixtures.FixtureModule
+
+  require Record
+  Record.defrecord(
+    :aws_config,
+    Record.extract(:aws_config,
+                   from_lib: "erlcloud/include/erlcloud_aws.hrl")
+  )
+
+  deffixture config, autouse: true do
+    aws_config(sqs_host: 'localhost',
+               sqs_protocol: 'http',
+               sqs_port: 4567,
+               access_key_id: 'test',
+               secret_access_key: 'test')
+  end
+
+  deffixture queue(config) do
+    name = random_queue_name
+    [queue_url: _] = :erlcloud_sqs.create_queue(name, config)
+
+    on_exit fn ->
+      try do
+        :erlcloud_sqs.delete_queue(name, config)
+      rescue
+        _ -> nil # Ignore errors, the test may have deleted the queue.
+      end
+    end
+
+    name
+  end
+
+  defp random_queue_name do
+    UUID.uuid4() |> to_char_list
+  end
+end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,3 +1,4 @@
 ExUnit.start()
 ExUnit.configure(capture_log: true)
 :erlcloud.start()
+ExUnitFixtures.start()


### PR DESCRIPTION
This refactors `vassal_test.exs`:
- Moves it into integration_tests folder so we can have multiple test modules rather than piling it all into a single file.
- Moves the fixtures out into fixtures.exs so that ExUnitFixtures picks it up automatically, and the code can be shared.
- Some minor tweaks to the tests themselves (using @moduletag to provide defaults etc).
- Fixed an elixir 1.2 warning that'd been appearing for a while.
